### PR TITLE
feat: improve templates feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ get_kafka_creds {tenant}
   This template is used with the `register_app` command.
   Defaults to `{TEMPLATES_PATH}/cors_template.json`.
 
+- `OIDC_TEMPLATE_PATH`: Path to Kong service OIDC plugin template file.
+  This template is used with the `add_service` and `add_solution` commands.
+  Defaults to `{TEMPLATES_PATH}/oidc_template.json`.
+
 - `REALM_TEMPLATE_PATH`: Path to keycloak realm template file.
   This template is used with the `add_solution` and `add_service` commands.
   Defaults to `{TEMPLATES_PATH}/realm_template.json`.
@@ -222,8 +226,8 @@ get_kafka_creds {tenant}
 
 ### Keycloak
 
-- `KEYCLOAK_INTERNAL`: Keycloak internal URL. Usually `http://keycloak:8080`.
-- `KEYCLOAK_PATH`: Keycloak path to the authorization section. Defaults to `/auth/`.
+- `KEYCLOAK_INTERNAL`: Keycloak internal URL. Usually `http://keycloak:8080/auth/`.
+  **Note**: Ending `/` is required to connect to admin console.
 - `KEYCLOAK_MASTER_REALM`: Keycloak master realm name. Defaults to `master`.
 - `KEYCLOAK_GLOBAL_ADMIN`: Keycloak admin user name in the master realm.
 - `KEYCLOAK_GLOBAL_PASSWORD`: Keycloak admin user password in the master realm.

--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ get_kafka_creds {tenant}
 
 - `SOLUTIONS_PATH`: Path to solution files directory. Defaults to `/code/solution`.
 
+### Templates
+
 - `TEMPLATES_PATH`: Path to template files directory.
   Defaults to `/code/templates`.
 
@@ -223,6 +225,24 @@ get_kafka_creds {tenant}
 - `ES_ROLE_TEMPLATE_PATH`: Path to ElasticSearch role template file.
   This template is used with the `add_elasticsearch_tenant` command.
   Defaults to `{TEMPLATES_PATH}/es_role_template.json`.
+
+All of these templates are going to be parsed using the
+[python template strings feature](https://docs.python.org/3/library/string.html#template-strings).
+This means that even the keys or the values can contain `$-based` strings that
+will be replaced with the environment variable or command argument values.
+
+Some of the expected `$-based` strings are:
+- `domain`: replaced with `BASE_DOMAIN` environment variable value.
+- `host`: replaced with `BASE_HOST` environment variable value.
+- `realm`: replaced with the `realm`command argument value.
+- `tenant`: replaced with the `tenant` command argument value.
+- `publicRealm`: replaced with `PUBLIC_REALM` environment variable value.
+- `oidc_client_id`: replaced with the `oidc-client` command argument value.
+- `oidc_client_secret`: replaced with `oidc` client secret fetched form Keycloak.
+- `username`: replaced with the `username` command argument value.
+- `email`: replaced with the `email` command argument value.
+
+Review the code to get the expected strings in each case.
 
 ### Keycloak
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,10 @@ get_kafka_creds {tenant}
   This template is used with the `add_user` command while creating non admin users.
   Defaults to `{TEMPLATES_PATH}/user_standard_template.json`.
 
+- `ES_ROLE_TEMPLATE_PATH`: Path to ElasticSearch role template file.
+  This template is used with the `add_elasticsearch_tenant` command.
+  Defaults to `{TEMPLATES_PATH}/es_role_template.json`.
+
 ### Keycloak
 
 - `KEYCLOAK_INTERNAL`: Keycloak internal URL. Usually `http://keycloak:8080`.

--- a/gateway-manager/src/helpers.py
+++ b/gateway-manager/src/helpers.py
@@ -60,7 +60,6 @@ def load_json_file(json_file_path, mapping=None):
 
     try:
         with open(json_file_path) as _f:
-            # data = json.load(_f)
             content = _f.read().replace('\n', '')
             if mapping:
                 content = Template(content).safe_substitute(mapping)

--- a/gateway-manager/src/helpers.py
+++ b/gateway-manager/src/helpers.py
@@ -20,6 +20,8 @@ import coloredlogs
 import logging
 import json
 import requests
+
+from string import Template
 from requests.exceptions import HTTPError
 
 from settings import DEBUG
@@ -43,12 +45,26 @@ def request(*args, **kwargs):
         __handle_exception(_logger, e)
 
 
-def load_json_file(json_file_path):
+def fill_template(template_str, mapping):
+    # take only the required values for formatting
+    swaps = {
+        k: v
+        for k, v in mapping.items()
+        if ('{%s}' % k) in template_str
+    }
+    return template_str.format(**swaps)
+
+
+def load_json_file(json_file_path, mapping=None):
     _logger = get_logger('json')
 
     try:
         with open(json_file_path) as _f:
-            data = json.load(_f)
+            # data = json.load(_f)
+            content = _f.read().replace('\n', '')
+            if mapping:
+                content = Template(content).safe_substitute(mapping)
+            data = json.loads(content)
         return data
     except Exception as e:
         __handle_exception(_logger, e)

--- a/gateway-manager/src/manage_kafka.py
+++ b/gateway-manager/src/manage_kafka.py
@@ -30,7 +30,6 @@ from zookeeper_functions import (
 )
 
 ZK_LAG_TIME = 3
-ZOOKEEPER = get_zookeeper()
 
 
 def create_superuser(name, password):
@@ -85,7 +84,7 @@ def tenant_creds(realm):
     logger.info(f'{realm} : {pw}')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     logger = get_logger('Kafka')
 
     COMMANDS = {
@@ -99,6 +98,8 @@ if __name__ == "__main__":
     if command.upper() not in COMMANDS.keys():
         logger.critical(f'No command: {command}')
         sys.exit(1)
+
+    ZOOKEEPER = get_zookeeper()
 
     fn = COMMANDS[command]
     args = sys.argv[2:]

--- a/gateway-manager/src/manage_kong.py
+++ b/gateway-manager/src/manage_kong.py
@@ -25,7 +25,7 @@ from typing import Callable, Dict
 from requests.exceptions import HTTPError
 
 from manage_keycloak import get_client_secret
-from helpers import request, load_json_file, get_logger
+from helpers import request, load_json_file, fill_template, get_logger
 from settings import (
     BASE_HOST,
     BASE_DOMAIN,
@@ -72,16 +72,6 @@ def _get_service_oidc_payload(service_name, realm, client_id):
         'config.user_url': f'{_KC_REALMS}/{realm}/{_OPENID_PATH}/userinfo',
         'config.realm': realm,
     }
-
-
-def _fill_template(template_str, replacements):
-    # take only the required values for formatting
-    swaps = {
-        k: v
-        for k, v in replacements.items()
-        if ('{%s}' % k) in template_str
-    }
-    return template_str.format(**swaps)
 
 
 def _check_realm_in_action(action, realm):
@@ -189,7 +179,7 @@ def add_service(service_config, realm, oidc_client):
         for ep in endpoints:
             context = dict({'realm': realm}, **ep)
             ep_name = ep['name']
-            ep_url = _fill_template(ep.get('url'), context)
+            ep_url = fill_template(ep.get('url'), context)
             service_name = f'{name}_{ep_type}_{ep_name}'
             data = {
                 'name': service_name,
@@ -204,7 +194,7 @@ def add_service(service_config, realm, oidc_client):
 
             ROUTE_URL = f'{KONG_INTERNAL_URL}/services/{service_name}/routes'
             if ep.get('template_path'):
-                path = _fill_template(ep.get('template_path'), context)
+                path = fill_template(ep.get('template_path'), context)
             else:
                 path = ep.get('route_path') or f'/{realm}/{name}{ep_url}'
 

--- a/gateway-manager/src/settings.py
+++ b/gateway-manager/src/settings.py
@@ -60,6 +60,13 @@ TEMPLATES = {
             f'{_TEMPLATES_PATH}/user_standard_template.json'
         ),
     },
+
+    'es': {
+        'role': get_env(
+            'ES_ROLE_TEMPLATE_PATH',
+            f'{_TEMPLATES_PATH}/es_role_template.json'
+        ),
+    }
 }
 
 # Keycloak Information

--- a/gateway-manager/src/settings.py
+++ b/gateway-manager/src/settings.py
@@ -38,6 +38,10 @@ TEMPLATES = {
         'CORS_TEMPLATE_PATH',
         f'{_TEMPLATES_PATH}/cors_template.json'
     ),
+    'oidc': get_env(
+        'OIDC_TEMPLATE_PATH',
+        f'{_TEMPLATES_PATH}/oidc_template.json'
+    ),
 
     'realm': get_env(
         'REALM_TEMPLATE_PATH',
@@ -69,14 +73,10 @@ TEMPLATES = {
     }
 }
 
+
 # Keycloak Information
 
-_KEYCLOAK_INTERNAL = get_env('KEYCLOAK_INTERNAL')
-_KEYCLOAK_PATH = get_env('KEYCLOAK_PATH', '/auth/')
-KEYCLOAK_PUBLIC_URL = f'{BASE_HOST}{_KEYCLOAK_PATH}'
-
-# Use internal URL with KeycloakAdmin
-KC_ADMIN_URL = f'{_KEYCLOAK_INTERNAL}{_KEYCLOAK_PATH}'
+KC_ADMIN_URL = get_env('KEYCLOAK_INTERNAL')     # http://keycloak:8080/auth/
 KC_ADMIN_USER = get_env('KEYCLOAK_GLOBAL_ADMIN')
 KC_ADMIN_PASSWORD = get_env('KEYCLOAK_GLOBAL_PASSWORD')
 KC_ADMIN_REALM = get_env('KEYCLOAK_MASTER_REALM', 'master')
@@ -84,16 +84,15 @@ KC_ADMIN_REALM = get_env('KEYCLOAK_MASTER_REALM', 'master')
 
 # Kong Information
 
-KONG_INTERNAL_URL = get_env('KONG_INTERNAL')
-KONG_OIDC_PLUGIN = 'kong-oidc-auth'
+KONG_INTERNAL_URL = get_env('KONG_INTERNAL')    # http://kong:8001
 KONG_PUBLIC_REALM = get_env('PUBLIC_REALM', '-')
 
 
 # Kafka && Zookeeper
 
-ZK_HOST = get_env('ZOOKEEPER_HOST')             # '127.0.0.1:32181'
-ZK_USER = get_env('ZOOKEEPER_USER')             # 'zk-admin'
-ZK_PW = get_env('ZOOKEEPER_PW')                 # 'password'
+ZK_HOST = get_env('ZOOKEEPER_HOST')             # 127.0.0.1:32181
+ZK_USER = get_env('ZOOKEEPER_USER')             # zk-admin
+ZK_PW = get_env('ZOOKEEPER_PW')                 # password
 # registered administrative credentials
 KAFKA_ADMIN_SECRET = get_env('KAFKA_SECRET')
 

--- a/gateway-manager/templates/client_template.json
+++ b/gateway-manager/templates/client_template.json
@@ -1,9 +1,11 @@
 {
+  "clientId": "${name}",
+  "baseUrl": "${host}/${realm}/",
   "clientAuthenticatorType": "client-secret",
   "directAccessGrantsEnabled": true,
   "enabled": true,
   "publicClient": true,
-  "redirectUris": ["*"],
+  "redirectUris": ["*", "${host}/${publicRealm}/*"],
   "protocolMappers": [
     {
       "name": "groups",

--- a/gateway-manager/templates/cors_template.json
+++ b/gateway-manager/templates/cors_template.json
@@ -5,5 +5,5 @@
   "config.headers": "Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, Authorization",
   "config.max_age": 3600,
   "config.methods": ["HEAD", "GET", "POST", "PUT", "PATCH", "DELETE"],
-  "config.origins": "/*"
+  "config.origins": "${host}/*"
 }

--- a/gateway-manager/templates/es_role_template.json
+++ b/gateway-manager/templates/es_role_template.json
@@ -1,0 +1,41 @@
+{
+  "cluster": [
+    "INDICES_MONITOR",
+    "CLUSTER_COMPOSITE_OPS"
+  ],
+  "indices": {
+    "*": {
+      "*": [
+        "indices:data/read/field_caps*",
+        "indices:data/read/xpack/rollup*",
+        "indices:admin/mappings/get*"
+      ]
+    },
+    "?kibana*${tenant}": {
+      "*": [
+        "MANAGE",
+        "INDEX",
+        "READ",
+        "DELETE"
+      ]
+    },
+    "?management-beats": {
+      "*": [
+        "INDICES_ALL"
+      ]
+    },
+    "?tasks": {
+      "*": [
+        "INDICES_ALL"
+      ]
+    },
+    "${tenant}*": {
+      "*": [
+        "UNLIMITED"
+      ]
+    }
+  },
+  "tenants": {
+    "${tenant}": "RW"
+  }
+}

--- a/gateway-manager/templates/oidc_template.json
+++ b/gateway-manager/templates/oidc_template.json
@@ -1,0 +1,19 @@
+{
+  "name": "kong-oidc-auth",
+
+  "config.client_id": "${oidc_client_id}",
+  "config.client_secret": "${oidc_client_secret}",
+  "config.cookie_domain": "${domain}",
+
+  "config.email_key": "email",
+  "config.scope": "openid+profile+email+iss",
+  "config.user_info_cache_enabled": "true",
+
+  "config.app_login_redirect_url": "${host}/${realm}/${service}/",
+  "config.authorize_url": "${host}/auth/realms/${realm}/protocol/openid-connect/auth",
+  "config.service_logout_url": "${host}/auth/realms/{realm}/protocol/openid-connect/logout",
+  "config.token_url": "${host}/auth/realms/{realm}/protocol/openid-connect/token",
+  "config.user_url": "${host}/auth/realms/{realm}/protocol/openid-connect/userinfo",
+
+  "config.realm": "${realm}"
+}

--- a/gateway-manager/templates/realm_template.json
+++ b/gateway-manager/templates/realm_template.json
@@ -1,5 +1,9 @@
 {
+  "realm": "${realm}",
+  "displayName": "${displayName}",
+  "loginTheme": "${loginTheme}",
   "enabled": true,
+  "sslRequired": "NONE",
   "requiredCredentials": ["password"],
   "roles": {
     "realm": [

--- a/gateway-manager/templates/user_admin_template.json
+++ b/gateway-manager/templates/user_admin_template.json
@@ -1,6 +1,6 @@
 {
-  "email": null,
+  "username": "${username}",
+  "email": "${email}",
   "enabled": true,
-  "realmRoles": ["admin", "user"],
-  "username": null
+  "realmRoles": ["admin", "user"]
 }

--- a/gateway-manager/templates/user_standard_template.json
+++ b/gateway-manager/templates/user_standard_template.json
@@ -1,6 +1,6 @@
 {
-  "email": null,
+  "username": "${username}",
+  "email": "${email}",
   "enabled": true,
-  "realmRoles": ["user"],
-  "username": null
+  "realmRoles": ["user"]
 }


### PR DESCRIPTION
Use Python template string to build the configuration using the JSON template files.
https://docs.python.org/3/library/string.html#template-strings

This will allow us to extend functionally changing only the files without rebuilding the container.

Added templates for Kong OIDC plugin and Elastic Search role.

**Note**: the template path utility in the service file remains unaltered. Still `{realm}/{url}-{name}` and not `$realm/${url}-$name`