### PR TITLE
feat: add apps using config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 This application is used to configure Keycloak+Kong installations,
 locally or as part of a cluster.
 
+## App
+
+An app represents an application and defines a set of public URLs.
+The main difference between an app and a service is that the app cannot be added to a realm.
+
+Continues in [App README](/gateway-manager/app/README.md)
+
 ## Service
 
 A service represents an application and defines a set of public and protected
@@ -84,50 +91,50 @@ decode_token {token}
 ### Kong
 
 #### `add_app` or `register_app`
-Registers an app as a service in Kong and serves it behind Kong (like NGINX).
+Registers an app as a service in Kong,
+using the app definition in `APPS_PATH` directory.
 
 ```bash
-add_app {app-name} {app-internal-url}
+add_app {app-name}
 # or
-register_app {app-name} {app-internal-url}
+register_app {app-name}
 ```
+
+> Note: The expected app file is `{APPS_PATH}/{app-name}.json`.
 
 #### `remove_app`
-Removes an app in Kong.
+Removes an app in Kong,
+using the app definition in `APPS_PATH` directory.
 
 ```bash
-remove_app {app_name}
+remove_app {app-name}
 ```
-
-#### `setup_auth`
-Registers Keycloak (the **auth** service) in Kong.
-
-Alias of:
-
-```bash
-register_app auth $KEYCLOAK_INTERNAL
-```
+> Note: The expected app file is `{APPS_PATH}/{app-name}.json`.
 
 #### `add_service`
 Adds a service to an existing realm in Kong,
 using the service definition in `SERVICES_PATH` directory.
 
 ```bash
-add_service {service} {realm} {oidc-client}
+add_service {service-name} {realm} {oidc-client}
 ```
+
+> Note: The expected service file is `{SERVICES_PATH}/{service-name}.json`.
 
 #### `remove_service`
 Removes a service from an existing realm in Kong,
 using the service definition in `SERVICES_PATH` directory.
 
 ```bash
-remove_service {service} {realm}
+remove_service {service-name} {realm}
 
 # removes service from all realms
-remove_service {service}
+remove_service {service-name}
 # or
-remove_service {service} "*"
+remove_service {service-name} "*"
 ```
+
+> Note: The expected service file is `{SERVICES_PATH}/{service-name}.json`.
 
 > Note: the service will not be enterily removed if it's still used by another realm.
 
@@ -136,21 +143,25 @@ Adds a package of services to an existing realm in Kong,
 using the solution definition in `SOLUTION_PATH` directory.
 
 ```bash
-add_solution {solution} {realm} {oidc-client}
+add_solution {solution-name} {realm} {oidc-client}
 ```
+
+> Note: The expected solution file is `{SOLUTION_PATH}/{solution-name}.json`.
 
 #### `remove_solution`
 Removes a package of services from an existing realm in Kong,
 using the solution definition in `SOLUTION_PATH` directory.
 
 ```bash
-remove_solution {solution} {realm}
+remove_solution {solution-name} {realm}
 
 # removes solution from all realms
-remove_solution {solution}
+remove_solution {solution-name}
 # or
-remove_solution {solution} "*"
+remove_solution {solution-name} "*"
 ```
+
+> Note: The expected solution file is `{SOLUTION_PATH}/{solution-name}.json`.
 
 > Note: the solution will not be enterily removed if it's still used by another realm.
 
@@ -164,7 +175,7 @@ add_kafka_su {username} {password}
 ```
 
 #### `grant_kafka_su`
-Give an existing user superuser status.
+Gives an existing user superuser status.
 
 ```bash
 grant_kafka_su {username}
@@ -210,6 +221,8 @@ add_elasticsearch_tenant {tenant}
 - `BASE_DOMAIN`: Installation hostname.
 
 - `BASE_HOST`: Installation hostname with protocol.
+
+- `APPS_PATH`: Path to app files directory. Defaults to `/code/app`.
 
 - `SERVICES_PATH`: Path to service files directory. Defaults to `/code/service`.
 

--- a/gateway-manager/apps/README.md
+++ b/gateway-manager/apps/README.md
@@ -1,0 +1,24 @@
+# App
+
+An app represents an application and defines a set of public URLs.
+The main difference between an app and a service is that the app cannot be added to a realm.
+
+
+The expected format for each app file is:
+
+```javascript
+{
+  // kong service name (unique among rest of apps and services)
+  "name": "app-service-name",
+
+  // internal host (behind kong)
+  "host": "http://my-app:8888",
+
+  // list of endpoints served behind Kong
+  "paths": [
+    "/path/to/resource-1",
+    "/path/to/resource-2",
+    "/path/to/resource-3"
+  ]
+}
+```

--- a/gateway-manager/apps/demo.json
+++ b/gateway-manager/apps/demo.json
@@ -1,0 +1,5 @@
+{
+  "name": "demo-app",
+  "host": "http://demo-app:8080",
+  "paths": [ "/endpoint-1", "endpoint-2" ]
+}

--- a/gateway-manager/entrypoint.sh
+++ b/gateway-manager/entrypoint.sh
@@ -80,12 +80,6 @@ function show_help {
     Kong
     ----------------------------------------------------------------------------
 
-    setup_auth:
-        Registers Keycloak (the auth service) in Kong.
-
-        Alias of:  add_app auth $KEYCLOAK_INTERNAL
-
-
     register_app | add_app:
         Registers an app in Kong.
 
@@ -141,7 +135,7 @@ function show_help {
 
 
     grant_kafka_su:
-        Give an existing user superuser status.
+        Gives an existing user superuser status.
 
         Usage:  grant_kafka_su {username}
 
@@ -162,13 +156,13 @@ function show_help {
     ----------------------------------------------------------------------------
 
     setup_elasticsearch:
-        Prepares ElasticSearch
+        Prepares ElasticSearch.
 
         Usage:  setup_elasticsearch
 
 
     add_elasticsearch_tenant:
-        Adds a tenant to ElasticSearch
+        Adds a tenant to ElasticSearch.
 
         Usage:  add_elasticsearch_tenant {tenant}
 
@@ -209,10 +203,6 @@ case "$1" in
     # --------------------------------------------------------------------------
     # Kong
     # --------------------------------------------------------------------------
-
-    setup_auth )
-        python /code/src/manage_kong.py APP ADD auth $KEYCLOAK_INTERNAL
-    ;;
 
     register_app | add_app )
         python /code/src/manage_kong.py APP ADD "${@:2}"

--- a/gateway-manager/service/README.md
+++ b/gateway-manager/service/README.md
@@ -7,7 +7,7 @@ The expected format for each service file is:
 
 ```javascript
 {
-  // service name (unique among rest of services)
+  // kong service name (unique among rest of services)
   "name": "service-name",
 
   // internal host (behind kong)

--- a/gateway-manager/service/demo.json
+++ b/gateway-manager/service/demo.json
@@ -1,5 +1,5 @@
 {
-  "name": "demo",
+  "name": "demo-service",
   "host": "http://demo-service:3013",
   "oidc_endpoints": [
     {

--- a/gateway-manager/src/settings.py
+++ b/gateway-manager/src/settings.py
@@ -29,6 +29,7 @@ DEBUG = bool(get_env('DEBUG'))
 BASE_HOST = get_env('BASE_HOST')
 BASE_DOMAIN = get_env('BASE_DOMAIN')
 
+APPS_PATH = get_env('APPS_PATH', '/code/app')
 SERVICES_PATH = get_env('SERVICES_PATH', '/code/service')
 SOLUTIONS_PATH = get_env('SOLUTIONS_PATH', '/code/solution')
 


### PR DESCRIPTION
- Removed command `setup_auth`
- Changed commands `add_app` and `remove_app`, like the other ones they depend on a config file.


```javascript
// keycloak.json
{
  "name": "keycloak",
  "host": "http://keycloak:8080",
  "paths": [ "/auth/" ]  //  the path is not the same as the service name
}
```

```javascript
// minio.json (in case we wanted to access the Minio Browser UI)
{
  "name": "minio-aether-in-aws",
  "host": "https://minio.aws.com",  // URL given by external provider
  "paths": [
    "/minio/kernel/",
    "/minio/odk/"
    // there could be more buckets used by other applications
    // that we don't want to expose in this kong installation
  ]
}
```