### PR TITLE
fix: avoid known errors like 409

### DIFF
--- a/gateway-manager/src/manage_elasticsearch.py
+++ b/gateway-manager/src/manage_elasticsearch.py
@@ -61,8 +61,7 @@ def is_es_ready():
         logger.success('ElasticSearch is ready!')
     except Exception as e:
         logger.critical('ElasticSearch is NOT ready!')
-        logger.error(str(e))
-        sys.exit(1)
+        raise e
 
 
 if __name__ == "__main__":
@@ -79,13 +78,12 @@ if __name__ == "__main__":
         logger.critical(f'No command: {command}')
         sys.exit(1)
 
-    AUTH = HTTPBasicAuth(ES_USER, ES_PW)
-    is_es_ready()
-
-    fn = COMMANDS[command]
-    args = sys.argv[2:]
-
     try:
+        AUTH = HTTPBasicAuth(ES_USER, ES_PW)
+        is_es_ready()
+
+        fn = COMMANDS[command]
+        args = sys.argv[2:]
         fn(*args)
     except Exception as e:
         logger.error(str(e))

--- a/gateway-manager/src/manage_keycloak.py
+++ b/gateway-manager/src/manage_keycloak.py
@@ -132,7 +132,13 @@ def create_user(
         config['email'] = None
 
     keycloak_admin = client_for_realm(realm)
-    _status = keycloak_admin.create_user(config)
+
+    _user_id = keycloak_admin.get_user_id(username=user)
+    if _user_id:
+        _status = keycloak_admin.update_user(_user_id, config)
+    else:
+        _status = keycloak_admin.create_user(config)
+
     if _status:
         logger.warning(f'- {str(_status)}')
 


### PR DESCRIPTION
Do not try to create the service if the service is already there while adding it to a realm.

### Expected logs

#### Adding a new service `ui` to a realm `dev`

```
[Kong]  Exposing service "ui" at http://ui:8004...
[request]  404 Client Error: Not Found for url: http://kong:8001/services/ui
[Kong]  Added service "ui": 632e0516-200f-4dc0-bc0b-656d95eba4ef
[Kong]  Added CORS plugin to service "ui"
[Kong]  Exposing service "ui" routes for realm "dev"...
[Kong]  Adding public endpoints...
[request]  404 Client Error: Not Found for url: http://kong:8001/services/ui/routes/ui__public__public__dev
[Kong]  Route paths ['/-/ui'] now being served at http://aether.local
[Kong]  Adding oidc endpoints...
[request]  404 Client Error: Not Found for url: http://kong:8001/services/ui/routes/ui__oidc__protected__dev
[Kong]  Route paths ['/dev/ui'] now being served at http://aether.local
[Kong]  Route paths ['/dev/ui'] now being protected
[Kong]  Service "ui" routes now being served and protected for realm "dev"
```

#### Adding the same service `ui` to another realm `test`

```
[Kong]  Exposing service "ui" at http://ui:8004...
[Kong]  Service "ui" already exists!
[Kong]  Exposing service "ui" routes for realm "test"...
[Kong]  Adding public endpoints...
[request]  404 Client Error: Not Found for url: http://kong:8001/services/ui/routes/ui__public__public__test
[Kong]  Route paths ['/-/ui'] now being served at http://aether.local
[Kong]  Adding oidc endpoints...
[request]  404 Client Error: Not Found for url: http://kong:8001/services/ui/routes/ui__oidc__protected__test
[Kong]  Route paths ['/test/ui'] now being served at http://aether.local
[Kong]  Route paths ['/test/ui'] now being protected
[Kong]  Service "ui" routes now being served and protected for realm "test"
```