### PR TITLE
fix: reduce the number of routes per service

### DIFF
--- a/gateway-manager/app/README.md
+++ b/gateway-manager/app/README.md
@@ -14,11 +14,23 @@ The expected format for each app file is:
   // internal host (behind kong)
   "host": "http://my-app:8888",
 
-  // list of endpoints served behind Kong
+  // list of regex paths served behind Kong
+  // Evaluates a path dynamically based on the following variables
+  // using string substitution:
+  //    {public_realm} is the kong public realm name,
+  //    {name}         is the service name
   "paths": [
     "/path/to/resource-1",
-    "/path/to/resource-2",
-    "/path/to/resource-3"
-  ]
+    "/{public_realm}/path/to/resource-2",
+    "/{name}/path/to/resource-3"
+  ],
+
+  // [optional] (defaults to "false")
+  // https://docs.konghq.com/1.1.x/proxy/
+  "strip_path": "true",
+
+  // [optional] (defaults to "0")
+  // https://docs.konghq.com/1.1.x/proxy/#evaluation-order
+  "regex_priority": 0
 }
 ```

--- a/gateway-manager/app/demo.json
+++ b/gateway-manager/app/demo.json
@@ -4,5 +4,7 @@
   "paths": [
     "/endpoint-1",
     "/endpoint-2"
-  ]
+  ],
+  "strip_path": "false",
+  "regex_priority": 1
 }

--- a/gateway-manager/service/README.md
+++ b/gateway-manager/service/README.md
@@ -13,6 +13,26 @@ The expected format for each service file is:
   // internal host (behind kong)
   "host": "http://my-service:8888",
 
+  // list of public regex paths served behind Kong
+  // Evaluates a path dynamically based on the following variables
+  // using string substitution:
+  //    {public_realm} is the kong public realm name,
+  //    {name}         is the service name
+  // These paths don't depend on the realm and are shared among all realms
+  "paths": [
+    "/path/to/resource-1",
+    "/{public_realm}/path/to/resource-2",
+    "/{name}/path/to/resource-3"
+  ],
+
+  // [optional] (defaults to "false")
+  // https://docs.konghq.com/1.1.x/proxy/
+  "strip_path": "true",
+
+  // [optional] (defaults to "0")
+  // https://docs.konghq.com/1.1.x/proxy/#evaluation-order
+  "regex_priority": 0,
+
   // list of urls protected by "kong-oidc-auth" plugin
   // all of these urls provide the X-Outh-Token header
   // or are redirected to keycloak to authenticate
@@ -65,8 +85,8 @@ The expected format for each service file is:
       //    {realm} is the realm name,
       //    {name}  is the service name
       "paths": [
-        "/{public_realm}/{name}/",
-        "/{name}/public/endpoint-2/\\d+"
+        "/{realm}/{name}/public",
+        "/{realm}/{name}/public/endpoint-2/\\d+"
       ],
 
       // [optional] (defaults to "false")

--- a/gateway-manager/service/demo.json
+++ b/gateway-manager/service/demo.json
@@ -1,27 +1,37 @@
 {
   "name": "demo-service",
   "host": "http://demo-service:3013",
+
+  "paths": [
+    "/{public_realm}/{name}/",
+    "/~/{name}/public",
+    "/-/\\d+/{name}/"
+  ],
+  "strip_path": "true",
+  "regex_priority": 0,
+
   "oidc_endpoints": [
     {
-      "name": "base",
+      "name": "protected",
       "paths": [
         "/{realm}/{name}/",
         "/{realm}/\\d+/{name}/"
       ],
       "strip_path": "false",
-      "regex_priority": 1
+      "regex_priority": 0
     }
   ],
+
   "public_endpoints": [
     {
       "name": "public",
       "paths": [
-        "/{public_realm}/{name}/",
-        "/~/{name}/public",
-        "/-/\\d+/{name}/"
+        "/{realm}/{name}/static",
+        "/{realm}/{name}/public",
+        "/{realm}/\\d+/{name}/assets"
       ],
       "strip_path": "true",
-      "regex_priority": 0
+      "regex_priority": 1
     }
   ]
 }

--- a/gateway-manager/src/manage_elasticsearch.py
+++ b/gateway-manager/src/manage_elasticsearch.py
@@ -35,38 +35,37 @@ from settings import (
 )
 
 API = f'{ES_HOST}/_opendistro/_security/api/'
+LOGGER = get_logger('ElasticSearch')
 
 
 def create_tenant(tenant):
     ROLES_URL = f'{API}roles/{tenant}'
     role = load_json_file(TEMPLATES['es']['role'], {'tenant': tenant})
     ok = request(method='put', url=ROLES_URL, auth=AUTH, json=role)
-    logger.info(f'tenant role: {ok}')
+    LOGGER.info(f'tenant role: {ok}')
 
     ROLES_MAPPING_URL = f'{API}rolesmapping/{tenant}'
     mapping = {'backendroles': [tenant]}
     ok = request(method='put', url=ROLES_MAPPING_URL, auth=AUTH, json=mapping)
-    logger.info(f'rolesmapping: {ok}')
+    LOGGER.info(f'rolesmapping: {ok}')
 
 
 def setup_es():
     OWN_INDEX_URL = f'{API}rolesmapping/own_index'
     ok = request(method='delete', url=OWN_INDEX_URL, auth=AUTH)
-    logger.info(f'remove user indexes: {ok}')
+    LOGGER.info(f'remove user indexes: {ok}')
 
 
 def is_es_ready():
     try:
         request(method='get', url=ES_HOST, auth=AUTH)
-        logger.success('ElasticSearch is ready!')
+        LOGGER.success('ElasticSearch is ready!')
     except Exception as e:
-        logger.critical('ElasticSearch is NOT ready!')
+        LOGGER.critical('ElasticSearch is NOT ready!')
         raise e
 
 
 if __name__ == "__main__":
-    logger = get_logger('ElasticSearch')
-
     COMMANDS = {
         'READY': do_nothing,
         'ADD_TENANT': create_tenant,
@@ -75,7 +74,7 @@ if __name__ == "__main__":
 
     command = sys.argv[1]
     if command.upper() not in COMMANDS.keys():
-        logger.critical(f'No command: {command}')
+        LOGGER.critical(f'No command: {command}')
         sys.exit(1)
 
     try:
@@ -86,5 +85,5 @@ if __name__ == "__main__":
         args = sys.argv[2:]
         fn(*args)
     except Exception as e:
-        logger.error(str(e))
+        LOGGER.error(str(e))
         sys.exit(1)

--- a/gateway-manager/src/manage_kafka.py
+++ b/gateway-manager/src/manage_kafka.py
@@ -30,11 +30,12 @@ from zookeeper_functions import (
 )
 
 ZK_LAG_TIME = 3
+LOGGER = get_logger('Kafka')
 
 
 def create_superuser(name, password):
     # make user for name
-    logger.info(f'Creating SuperUser: {name}')
+    LOGGER.info(f'Creating SuperUser: {name}')
     make_user(ZOOKEEPER, name, password)
     sleep(ZK_LAG_TIME)
     grant_superuser(name)
@@ -59,7 +60,7 @@ def grant_superuser(name):
 
 def create_tenant(realm):
     # make user for realm
-    logger.info(f'Creating tenant for realm: {realm}')
+    LOGGER.info(f'Creating tenant for realm: {realm}')
     pw = get_tenant_password(realm)
     make_user(ZOOKEEPER, realm, pw)
     sleep(ZK_LAG_TIME)
@@ -81,12 +82,10 @@ def create_tenant(realm):
 
 def tenant_creds(realm):
     pw = get_tenant_password(realm)
-    logger.info(f'{realm} : {pw}')
+    LOGGER.info(f'{realm} : {pw}')
 
 
 if __name__ == '__main__':
-    logger = get_logger('Kafka')
-
     COMMANDS = {
         'ADD_SUPERUSER': create_superuser,
         'GRANT_SUPERUSER': grant_superuser,
@@ -96,11 +95,15 @@ if __name__ == '__main__':
 
     command = sys.argv[1]
     if command.upper() not in COMMANDS.keys():
-        logger.critical(f'No command: {command}')
+        LOGGER.critical(f'No command: {command}')
         sys.exit(1)
 
-    ZOOKEEPER = get_zookeeper()
+    try:
+        ZOOKEEPER = get_zookeeper()
 
-    fn = COMMANDS[command]
-    args = sys.argv[2:]
-    fn(*args)
+        fn = COMMANDS[command]
+        args = sys.argv[2:]
+        fn(*args)
+    except Exception as e:
+        LOGGER.error(str(e))
+        sys.exit(1)

--- a/gateway-manager/src/zookeeper_functions.py
+++ b/gateway-manager/src/zookeeper_functions.py
@@ -244,9 +244,13 @@ def get_zookeeper():
     zookeeper.start()
     return zookeeper
 
+
 if __name__ == '__main__':
-    logger = get_logger('Zookeeper')
-    zookeeper = get_zookeeper()
-    # when run directly, you can view entities within zookeeper for debugging
-    starting_path = sys.argv[1] or ''
-    loot(zookeeper, starting_path)
+    try:
+        zookeeper = get_zookeeper()
+        # when run directly, you can view entities within zookeeper for debugging
+        starting_path = sys.argv[1] or ''
+        loot(zookeeper, starting_path)
+    except Exception as e:
+        LOGGER.error(str(e))
+        sys.exit(1)


### PR DESCRIPTION
With the previous approach, we were adding the same route (`/-/kernel`) for all the realms, forcing kong to evaluate which one choose in each case. Now we create that route only once. This wasn't a thing having a couple of realms, but having thousands of realms...