### PR TITLE
feat: fixed roles template and background_roles to align with 7.x syntax

### DIFF
--- a/gateway-manager/src/manage_elasticsearch.py
+++ b/gateway-manager/src/manage_elasticsearch.py
@@ -38,14 +38,20 @@ API = f'{ES_HOST}/_opendistro/_security/api/'
 LOGGER = get_logger('ElasticSearch')
 
 
-def create_tenant(tenant):
+def create_tenant(tenant, version=6):
     ROLES_URL = f'{API}roles/{tenant}'
-    role = load_json_file(TEMPLATES['es']['role'], {'tenant': tenant})
+    if version < 7:
+        role = load_json_file(TEMPLATES['es']['role'], {'tenant': tenant})
+    else:
+        role = load_json_file(TEMPLATES['es7']['role'], {'tenant': tenant})
     ok = request(method='put', url=ROLES_URL, auth=AUTH, json=role)
     LOGGER.info(f'tenant role: {ok}')
 
     ROLES_MAPPING_URL = f'{API}rolesmapping/{tenant}'
-    mapping = {'backendroles': [tenant]}
+    if version < 7:
+        mapping = {'backendroles': [tenant]}
+    else:
+        mapping = {'backend_roles': [tenant]}
     ok = request(method='put', url=ROLES_MAPPING_URL, auth=AUTH, json=mapping)
     LOGGER.info(f'rolesmapping: {ok}')
 

--- a/gateway-manager/templates/es7_role_template.json
+++ b/gateway-manager/templates/es7_role_template.json
@@ -1,0 +1,53 @@
+{
+  "description": "Roles for users of realm: ${tenant}",
+  "cluster_permissions": [
+    "indices_monitor",
+    "cluster_composite_ops"
+  ],
+  "index_permissions": [
+    {
+      "index_patterns": [
+        "${tenant}*"
+      ],
+      "fls": [],
+      "masked_fields": [],
+      "allowed_actions": [
+        "unlimited"
+      ]
+    },
+    {
+      "index_patterns": [
+        "?kibana*${tenant}"
+      ],
+      "fls": [],
+      "masked_fields": [],
+      "allowed_actions": [
+        "read",
+        "delete",
+        "manage",
+        "index"
+      ]
+    },
+    {
+      "index_patterns": [
+        "?tasks",
+        "?management-beats"
+      ],
+      "fls": [],
+      "masked_fields": [],
+      "allowed_actions": [
+        "indices_all"
+      ]
+    }
+  ],
+  "tenant_permissions": [
+    {
+      "tenant_patterns": [
+        "${tenant}"
+      ],
+      "allowed_actions": [
+        "kibana_all_write"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This lets us optionally use ES7 syntax. Default remains 6.x until we figure out he issues with OIDC 1.x and their security protocol.