### PR TITLE
fix: add tenant artifact creation for kibana 7+

### DIFF
--- a/gateway-manager/src/manage_elasticsearch.py
+++ b/gateway-manager/src/manage_elasticsearch.py
@@ -55,7 +55,7 @@ def create_tenant(tenant, version=6):
     ok = request(method='put', url=ROLES_MAPPING_URL, auth=AUTH, json=mapping)
     LOGGER.info(f'rolesmapping: {ok}')
 
-    if version < 7:
+    if int(version) < 7:
         return
 
     TENANT_URL = f'{API}tenants/{tenant}'

--- a/gateway-manager/src/manage_elasticsearch.py
+++ b/gateway-manager/src/manage_elasticsearch.py
@@ -55,6 +55,14 @@ def create_tenant(tenant, version=6):
     ok = request(method='put', url=ROLES_MAPPING_URL, auth=AUTH, json=mapping)
     LOGGER.info(f'rolesmapping: {ok}')
 
+    if version < 7:
+        return
+
+    TENANT_URL = f'{API}tenants/{tenant}'
+    tenant_desc = {'description': f'Tenant for {tenant}'}
+    ok = request(method='put', url=TENANT_URL, auth=AUTH, json=tenant_desc)
+    LOGGER.info(f'tenant: {ok}')
+
 
 def setup_es():
     OWN_INDEX_URL = f'{API}rolesmapping/own_index'


### PR DESCRIPTION
Kibana 7 requires a new tenant artifact be registered in conjunction with the other roles/ backend roles.