### PR TITLE
fix: add content-disposition to allowed headers

### DIFF
--- a/gateway-manager/templates/cors_template.json
+++ b/gateway-manager/templates/cors_template.json
@@ -1,7 +1,7 @@
 {
   "name": "cors",
   "config.credentials": "true",
-  "config.exposed_headers": "Authorization",
+  "config.exposed_headers": "Authorization, Content-Disposition",
   "config.headers": "Accept, Accept-Version, Content-Disposition, Content-Length, Content-MD5, Content-Type, Date, Authorization",
   "config.max_age": 3600,
   "config.methods": ["HEAD", "GET", "POST", "PUT", "PATCH", "DELETE"],

--- a/gateway-manager/templates/cors_template.json
+++ b/gateway-manager/templates/cors_template.json
@@ -2,7 +2,7 @@
   "name": "cors",
   "config.credentials": "true",
   "config.exposed_headers": "Authorization",
-  "config.headers": "Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, Authorization",
+  "config.headers": "Accept, Accept-Version, Content-Disposition, Content-Length, Content-MD5, Content-Type, Date, Authorization",
   "config.max_age": 3600,
   "config.methods": ["HEAD", "GET", "POST", "PUT", "PATCH", "DELETE"],
   "config.origins": "${host}/*"


### PR DESCRIPTION
Content Disposition is required for Gather file downloads.