### PR TITLE
chore(gwm): upgrade to python 3.8

### DIFF
--- a/gateway-manager/Dockerfile
+++ b/gateway-manager/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-buster
+FROM python:3.8-slim-buster
 
 WORKDIR /code
 

--- a/gateway-manager/conf/pip/requirements.txt
+++ b/gateway-manager/conf/pip/requirements.txt
@@ -40,4 +40,6 @@ python-keycloak>=0.17
 # Implements a higher level API to Apache Zookeeper for Python clients.
 # https://kazoo.readthedocs.io/en/latest/
 # kazoo
-git+https://github.com/python-zk/kazoo.git@88b657a0977161f3815657878ba48f82a97a3846#egg=kazoo
+# https://github.com/python-zk/kazoo/blob/master/CHANGES.md#270-2020-03-13
+# git+https://github.com/python-zk/kazoo.git@88b657a0977161f3815657878ba48f82a97a3846#egg=kazoo
+kazoo>=2.7.0

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -20,7 +20,7 @@
 #
 set -Eeuo pipefail
 
-GWM_VERSION=latest
+GW_VERSION=latest
 
 function build_image {
     APP=$1
@@ -51,12 +51,16 @@ function build_image {
     echo -e ""
 }
 
-build_image gateway-home ${GWM_VERSION} gateway-manager/home
+# Home page
+build_image gateway-home ${GW_VERSION} gateway-manager/home
 docker run \
     --volume $PWD/gateway-manager/build:/code/app/build \
     --rm gateway-home build
-build_image gateway-manager ${GWM_VERSION}
 
+# GW Manager
+build_image gateway-manager ${GW_VERSION}
+
+# Custom Kong
 KONG_RELEASES=( "1.3" "1.4" "1.5" "2.0" "2.1" "latest" )
 for kong_version in "${KONG_RELEASES[@]}"; do
     build_image  kong  $kong_version

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -59,13 +59,18 @@ function build_and_push {
 }
 
 # If there is no tag then create image for branch develop
-GATEWAY_VERSION=${TRAVIS_TAG:-latest}
-build_image gateway-home ${GWM_VERSION} gateway-manager/home
+GW_VERSION=${TRAVIS_TAG:-latest}
+
+# Home page
+build_image gateway-home ${GW_VERSION} gateway-manager/home
 docker run \
     --volume $PWD/gateway-manager/build:/code/app/build \
     --rm gateway-home build
-build_and_push  gateway-manager  $GATEWAY_VERSION
 
+# GW Manager
+build_and_push  gateway-manager  ${GW_VERSION}
+
+# Custom Kong
 KONG_RELEASES=( "1.3" "1.4" "1.5" "2.0" "2.1" "latest" )
 for kong_version in "${KONG_RELEASES[@]}"; do
     build_and_push  kong  $kong_version


### PR DESCRIPTION
Regarding kazzo, commit `88b657a0977161f3815657878ba48f82a97a3846` was already included in release [2.7.0](https://github.com/python-zk/kazoo/blob/master/CHANGES.md#270-2020-03-13)