### PR TITLE
feat: create realm with auth groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Shows the help message with all the possible commands.
 Runs bash inside the container.
 
 #### `eval`
-Evals shell command inside the container.
+Evaluates shell command inside the container.
 
 ### Keycloak
 
@@ -57,7 +57,11 @@ Checks the Keycloak connection. Returns status `0` on success.
 Adds a new realm in Keycloak using a default realm template.
 
 ```bash
-add_realm {realm} {description (optional)} {login theme (optional)}
+add_realm {realm} {description (optional)} \
+          {login theme (optional)} \
+          {account theme (optional)} \
+          {admin theme (optional)} \
+          {email theme (optional)}
 ```
 
 #### `add_user`
@@ -145,7 +149,7 @@ remove_service {service-name} "*"
 
 > Note: The expected service file is `{SERVICES_PATH}/{service-name}.json`.
 
-> Note: the service will not be enterily removed if it's still used by another realm.
+> Note: the service will not be entirely removed if it's still used by another realm.
 
 #### `add_solution`
 Adds a package of services to an existing realm in Kong,
@@ -172,7 +176,7 @@ remove_solution {solution-name} "*"
 
 > Note: The expected solution file is `{SOLUTION_PATH}/{solution-name}.json`.
 
-> Note: the solution will not be enterily removed if it's still used by another realm.
+> Note: the solution will not be entirely removed if it's still used by another realm.
 
 ### Kafka
 

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ Checks the Keycloak connection. Returns status `0` on success.
 Adds a new realm in Keycloak using a default realm template.
 
 ```bash
-add_realm {realm} {description (optional)} \
-          {login theme (optional)} \
-          {account theme (optional)} \
-          {admin theme (optional)} \
-          {email theme (optional)}
+add_realm {realm} {*description} \
+          {*login theme} \
+          {*account theme} \
+          {*admin theme} \
+          {*email theme}
 ```
 
 #### `add_admin`
@@ -268,7 +268,7 @@ delete_ccloud_tenant {username}
 Adds a ccloud APIKey for a tenant.
 
 ```bash
-add_ccloud_key {tenant} "{description (optional)}"
+add_ccloud_key {tenant} "{*description}"
 ```
 
 #### `list_ccloud_tenants`
@@ -282,7 +282,7 @@ list_ccloud_tenants
 Lists ACLs of CCloud tenants, or of a single tenant referenced by name
 
 ```bash
-list_ccloud_acls {tenant (optional) }
+list_ccloud_acls {*tenant}
 ```
 
 #### `list_ccloud_api_keys`

--- a/README.md
+++ b/README.md
@@ -64,13 +64,25 @@ add_realm {realm} {description (optional)} \
           {email theme (optional)}
 ```
 
-#### `add_user`
-Adds a user to an existing realm in Keycloak.
+#### `add_admin`
+Adds or updates an admin user to an existing realm in Keycloak.
 
 ```bash
-add_user {realm} {username} \
-         {*password} {*is_administrator} \
-         {*email} {*reset_password_on_login}
+add_user {realm} {username} {*password} {*reset_password_on_login}
+```
+
+#### `add_user`
+Adds or updates a user to an existing realm in Keycloak.
+
+```bash
+add_user {realm} {username} {*password} {*reset_password_on_login}
+```
+
+#### `add_user_group`
+Adds an existing user to a group on an existing realm in Keycloak.
+
+```bash
+add_user_group {realm} {username} {group_id}
 ```
 
 #### `add_confidential_client` or `add_oidc_client`

--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@ add_realm {realm} {description (optional)} \
 Adds or updates an admin user to an existing realm in Keycloak.
 
 ```bash
-add_user {realm} {username} {*password} {*reset_password_on_login}
+add_user {realm} {username} {*password} {*reset_password_on_first_login}
 ```
 
 #### `add_user`
 Adds or updates a user to an existing realm in Keycloak.
 
 ```bash
-add_user {realm} {username} {*password} {*reset_password_on_login}
+add_user {realm} {username} {*password} {*reset_password_on_first_login}
 ```
 
 #### `add_user_group`

--- a/gateway-manager/entrypoint.sh
+++ b/gateway-manager/entrypoint.sh
@@ -56,11 +56,11 @@ function show_help {
     add_realm:
         Adds a new realm using a default realm template.
 
-        Usage:  add_realm {realm} {description (optional)}
-                          {login theme (optional)}
-                          {account theme (optional)}
-                          {admin theme (optional)}
-                          {email theme (optional)}
+        Usage:  add_realm {realm} {*description}
+                          {*login theme}
+                          {*account theme}
+                          {*admin theme}
+                          {*email theme}
 
 
     add_admin:
@@ -219,7 +219,7 @@ function show_help {
     add_ccloud_key
         Adds a ccloud APIKey for a tenant.
 
-        Usage:  add_ccloud_key {tenant}  '{description (optional)}'
+        Usage:  add_ccloud_key {tenant} '{*description}'
 
 
     list_ccloud_tenants
@@ -231,7 +231,7 @@ function show_help {
     list_ccloud_acls
         Lists ACLs of CCloud tenants, or of a single tenant referenced by name
 
-        Usage:  list_ccloud_acls {tenant  (optional)}
+        Usage:  list_ccloud_acls {*tenant}
 
 
     list_ccloud_api_keys

--- a/gateway-manager/entrypoint.sh
+++ b/gateway-manager/entrypoint.sh
@@ -37,7 +37,7 @@ function show_help {
         Runs bash.
 
     eval:
-        Evals shell command.
+        Evaluates shell command.
 
 
     Home App
@@ -56,7 +56,11 @@ function show_help {
     add_realm:
         Adds a new realm using a default realm template.
 
-        Usage:  add_realm {realm} {description (optional)} {login theme (optional)}
+        Usage:  add_realm {realm} {description (optional)}
+                          {login theme (optional)}
+                          {account theme (optional)}
+                          {admin theme (optional)}
+                          {email theme (optional)}
 
 
     add_user:

--- a/gateway-manager/entrypoint.sh
+++ b/gateway-manager/entrypoint.sh
@@ -64,21 +64,21 @@ function show_help {
 
 
     add_admin:
-        Adds or updates an admin user to an existing realm in Keycloak.
+        Adds or updates an admin user to an existing realm.
 
         Usage:  add_admin {realm} {username}
-                          {*password} {*reset_password_on_login}
+                          {*password} {*reset_password_on_first_login}
 
 
     add_user:
-        Adds or updates a user to an existing realm in Keycloak.
+        Adds or updates a user to an existing realm.
 
         Usage:  add_user {realm} {username}
-                         {*password} {*reset_password_on_login}
+                         {*password} {*reset_password_on_first_login}
 
 
     add_user_group:
-        Adds an existing user to a group on an existing realm in Keycloak.
+        Adds an existing user to an existing group on an existing realm.
 
         Usage:  add_user_group {realm} {username} {group_id}
 

--- a/gateway-manager/entrypoint.sh
+++ b/gateway-manager/entrypoint.sh
@@ -63,12 +63,24 @@ function show_help {
                           {email theme (optional)}
 
 
+    add_admin:
+        Adds or updates an admin user to an existing realm in Keycloak.
+
+        Usage:  add_admin {realm} {username}
+                          {*password} {*reset_password_on_login}
+
+
     add_user:
-        Adds a user to an existing realm.
+        Adds or updates a user to an existing realm in Keycloak.
 
         Usage:  add_user {realm} {username}
-                         {*password} {*is_administrator}
-                         {*email} {*reset_password_on_login}
+                         {*password} {*reset_password_on_login}
+
+
+    add_user_group:
+        Adds an existing user to a group on an existing realm in Keycloak.
+
+        Usage:  add_user_group {realm} {username} {group_id}
 
 
     add_confidential_client | add_oidc_client:
@@ -267,8 +279,16 @@ case "$1" in
         python /code/src/manage_keycloak.py ADD_REALM "${@:2}"
     ;;
 
+    add_admin )
+        python /code/src/manage_keycloak.py ADD_ADMIN "${@:2}"
+    ;;
+
     add_user )
         python /code/src/manage_keycloak.py ADD_USER "${@:2}"
+    ;;
+
+    add_user_group )
+        python /code/src/manage_keycloak.py ADD_USER_GROUP "${@:2}"
     ;;
 
     add_confidential_client | add_oidc_client )

--- a/gateway-manager/src/manage_home_app.py
+++ b/gateway-manager/src/manage_home_app.py
@@ -50,8 +50,8 @@ def start_app():
 
         index_location = '/code/build/index.html'
         with open(index_location, 'r') as fp:
-            index = fp.read()
-        new_index = index.replace('/static', f'{cdn}/static') \
+            _index = fp.read()
+        new_index = _index.replace('/static', f'{cdn}/static') \
             .replace('/aether.ico', f'{cdn}/aether.ico')
 
         with open(index_location, 'w') as fp:

--- a/gateway-manager/src/manage_keycloak.py
+++ b/gateway-manager/src/manage_keycloak.py
@@ -157,7 +157,14 @@ def assign_all_client_roles(realm, username, client_name):
                    f' to "{username}" on realm "{realm}"')
 
 
-def create_realm(realm, description=None, login_theme=None):
+def create_realm(
+    realm,
+    description=None,
+    login_theme=None,
+    account_theme=None,
+    admin_theme=None,
+    email_theme=None,
+):
     check_realm(realm)
 
     LOGGER.info(f'Adding realm "{realm}"...')
@@ -165,13 +172,14 @@ def create_realm(realm, description=None, login_theme=None):
 
     config = load_json_file(TEMPLATES['realm'], {
         'realm': realm,
-        'displayName': description or '',
-        'loginTheme': login_theme or '',
+        'displayName': description or realm,
+        'accountTheme': account_theme or 'keycloak',
+        'adminTheme': admin_theme or 'keycloak',
+        'emailTheme': email_theme or 'keycloak',
+        'loginTheme': login_theme or 'keycloak',
+        'host': BASE_HOST,
+        'publicRealm': KONG_PUBLIC_REALM,
     })
-    if not description:
-        config['displayName'] = None
-    if not login_theme:
-        config['loginTheme'] = None
 
     _status = keycloak_admin.create_realm(config, skip_exists=True)
     if _status:
@@ -220,6 +228,7 @@ def create_user(
         if _status_pwd:
             LOGGER.warning(f'- {str(_status_pwd)}')
     LOGGER.success(f'Added user "{user}" to realm "{realm}"')
+
     if admin:
         LOGGER.info(f'Granting user "{user}" admin rights on realm "{realm}"...')
         assign_all_client_roles(realm, user, 'realm-management')

--- a/gateway-manager/src/settings.py
+++ b/gateway-manager/src/settings.py
@@ -55,18 +55,6 @@ TEMPLATES = {
         f'{_TEMPLATES_PATH}/client_template.json'
     ),
 
-    'user': {
-        'admin': get_env(
-            'ADMIN_TEMPLATE_PATH',
-            f'{_TEMPLATES_PATH}/user_admin_template.json'
-        ),
-
-        'standard': get_env(
-            'USER_TEMPLATE_PATH',
-            f'{_TEMPLATES_PATH}/user_standard_template.json'
-        ),
-    },
-
     'es': {
         'role': get_env(
             'ES_ROLE_TEMPLATE_PATH',

--- a/gateway-manager/templates/realm_template.json
+++ b/gateway-manager/templates/realm_template.json
@@ -43,18 +43,18 @@
   },
   "groups": [
     {
-      "id": "${realm}-admin",
-      "name": "${displayName} Admin",
+      "id": "admin",
+      "name": "Admin",
       "realmRoles": ["${realm}-admin"]
     },
     {
-      "id": "${realm}-editor",
-      "name": "${displayName} Editor",
+      "id": "editor",
+      "name": "Editor",
       "realmRoles": ["${realm}-editor"]
     },
     {
-      "id": "${realm}-user",
-      "name": "${displayName} User",
+      "id": "user",
+      "name": "User",
       "realmRoles": ["${realm}-user"]
     }
   ]

--- a/gateway-manager/templates/realm_template.json
+++ b/gateway-manager/templates/realm_template.json
@@ -1,20 +1,61 @@
 {
   "realm": "${realm}",
   "displayName": "${displayName}",
-  "loginTheme": "${loginTheme}",
+
   "enabled": true,
   "sslRequired": "NONE",
   "requiredCredentials": ["password"],
+
+  "accountTheme": "${accountTheme}",
+  "adminTheme": "${adminTheme}",
+  "loginTheme": "${loginTheme}",
+  "emailTheme": "${emailTheme}",
+
+  "accessCodeLifespan": 1800,
+  "accessTokenLifespan": 1800,
+
   "roles": {
     "realm": [
       {
-        "name": "user",
-        "description": "User privileges"
+        "id": "${realm}-user",
+        "name": "${realm}-user",
+        "description": "${displayName} User"
       },
       {
-        "name": "admin",
-        "description": "Administrator privileges"
+        "id": "${realm}-editor",
+        "name": "${realm}-editor",
+        "description": "${displayName} Editor",
+        "composites": {
+          "realm": ["${realm}-user"]
+        }
+      },
+      {
+        "id": "${realm}-admin",
+        "name": "${realm}-admin",
+        "description": "${displayName} Admin",
+        "composites": {
+          "client": {
+            "realm-management": ["manage-users", "query-users"]
+          }
+        }
       }
     ]
-  }
+  },
+  "groups": [
+    {
+      "id": "${realm}-admin",
+      "name": "${displayName} Admin",
+      "realmRoles": ["${realm}-admin"]
+    },
+    {
+      "id": "${realm}-editor",
+      "name": "${displayName} Editor",
+      "realmRoles": ["${realm}-editor"]
+    },
+    {
+      "id": "${realm}-user",
+      "name": "${displayName} User",
+      "realmRoles": ["${realm}-user"]
+    }
+  ]
 }

--- a/gateway-manager/templates/user_admin_template.json
+++ b/gateway-manager/templates/user_admin_template.json
@@ -1,6 +1,0 @@
-{
-  "username": "${username}",
-  "email": "${email}",
-  "enabled": true,
-  "realmRoles": ["admin", "user"]
-}

--- a/gateway-manager/templates/user_standard_template.json
+++ b/gateway-manager/templates/user_standard_template.json
@@ -1,6 +1,0 @@
-{
-  "username": "${username}",
-  "email": "${email}",
-  "enabled": true,
-  "realmRoles": ["user"]
-}


### PR DESCRIPTION
- Create realm in Keycloak with authorization groups and all possible themes.

- Split `add_user` command in `add_admin`, `add_user` and `add_user_group` commands.
  Sadly the `realmRoles` and `clientRoles` properties within the config setting in `create_user/update_user` are ignored by keycloak so I simplified the command to the minimum.

https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_userrepresentation
