### PR TITLE
feat: add option handling to command line.

### DIFF
--- a/gateway-manager/entrypoint.sh
+++ b/gateway-manager/entrypoint.sh
@@ -258,22 +258,6 @@ function show_help {
 
         Usage:  add_elasticsearch_tenant {tenant}
 
-
-    Zeebe
-    ----------------------------------------------------------------------------
-
-    add_zeebe_auth:
-        Adds zeebe auth routes to a tenant
-
-        Usage:  add_zeebe_auth {tenant}
-
-
-    add_zeebe_monitor:
-        Adds zeebe_monitor application to a tenant that has Zeebe
-
-        Usage:  add_zeebe_monitor {tenant} {monitor-service-url}
-
-
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     Current version:  [${VERSION:-latest}]
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/gateway-manager/entrypoint.sh
+++ b/gateway-manager/entrypoint.sh
@@ -259,6 +259,21 @@ function show_help {
         Usage:  add_elasticsearch_tenant {tenant}
 
 
+    Zeebe
+    ----------------------------------------------------------------------------
+
+    add_zeebe_auth:
+        Adds zeebe auth routes to a tenant
+
+        Usage:  add_zeebe_auth {tenant}
+
+
+    add_zeebe_monitor:
+        Adds zeebe_monitor application to a tenant that has Zeebe
+
+        Usage:  add_zeebe_monitor {tenant} {monitor-service-url}
+
+
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     Current version:  [${VERSION:-latest}]
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/gateway-manager/service/demo-generic.json
+++ b/gateway-manager/service/demo-generic.json
@@ -1,0 +1,39 @@
+{
+  "name": "${service}",
+  "host": "${service_url}",
+
+  "paths": [
+    "/{realm}/{name}/",
+    "/{realm}/{name}$"
+  ],
+  "strip_path": "true",
+  "regex_priority": 0,
+
+  "oidc_endpoints": [
+    {
+      "name": "protected",
+      "paths": [
+        "/{realm}/{name}/",
+        "/{realm}/\\d+/{name}/"
+      ],
+      "strip_path": "false",
+      "regex_priority": 0,
+      "oidc_override": {
+        "config.app_login_redirect_url": "${host}/${realm}/${name}/home"
+      }
+    }
+  ],
+
+  "public_endpoints": [
+    {
+      "name": "public",
+      "paths": [
+        "/{realm}/{name}/static",
+        "/{realm}/{name}/public",
+        "/{realm}/\\d+/{name}/assets"
+      ],
+      "strip_path": "true",
+      "regex_priority": 1
+    }
+  ]
+}

--- a/gateway-manager/src/helpers.py
+++ b/gateway-manager/src/helpers.py
@@ -16,12 +16,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import coloredlogs
 import logging
 import json
-import requests
-
 from string import Template
+from typing import List, Tuple
+
+import coloredlogs
+import requests
 from requests.exceptions import HTTPError
 
 from settings import DEBUG, KC_ADMIN_REALM, KONG_PUBLIC_REALM
@@ -136,3 +137,18 @@ def get_logger(name):
     )
 
     return logger
+
+
+def is_kwarg(arg, collector):
+    try:
+        k, v = arg.split('=')
+    except ValueError:
+        return False
+    collector[k] = v
+    return True
+
+
+def categorize_arguments(argv) -> Tuple[List, dict]:
+    kwargs = {}
+    args = [i for i in argv if not is_kwarg(i, kwargs)]
+    return args, kwargs


### PR DESCRIPTION
 - Added handling of command line arguments like `a=1` and their passing into base functions as `options=**kwargs`
 - Added `test` flag handling to `add_service` function to output the partially rendered template expression
 - Added `service_url` & `service_name` options for templating in `add_service`
 - Added `demo-generic` service example that shows templating of `service_name` && `service_url`

```
add_service demo-generic arealm aclient service_url=http://the.url service_name=not-so-generic test=true

[Kong]  {'name': 'not-so-generic', 'host': 'http://the.url', 'paths': ['/{realm}/{name}/', '/{realm}/{name}$'], 'strip_path': 'true', 'regex_priority': 0, 'oidc_endpoints': [{'name': 'protected', 'paths': ['/{realm}/{name}/', '/{realm}/\\d+/{name}/'], 'strip_path': 'false', 'regex_priority': 0, 'oidc_override': {'config.app_login_redirect_url': 'http://aether.local/arealm/demo-generic/home'}}], 'public_endpoints': [{'name': 'public', 'paths': ['/{realm}/{name}/static', '/{realm}/{name}/public', '/{realm}/\\d+/{name}/assets'], 'strip_path': 'true', 'regex_priority': 1}]}

add_service demo arealm aclient test=true
[Kong]  {'name': 'demo-service', 'host': 'http://demo-service:3013', 'paths': ['/{public_realm}/{name}/', '/~/{name}/public', '/-/\\d+/{name}/'], 'strip_path': 'true', 'regex_priority': 0, 'oidc_endpoints': [{'name': 'protected', 'paths': ['/{realm}/{name}/', '/{realm}/\\d+/{name}/'], 'strip_path': 'false', 'regex_priority': 0, 'oidc_override': {'config.app_login_redirect_url': 'http://aether.local/arealm/demo-service/home'}}], 'public_endpoints': [{'name': 'public', 'paths': ['/{realm}/{name}/static', '/{realm}/{name}/public', '/{realm}/\\d+/{name}/assets'], 'strip_path': 'true', 'regex_priority': 1}]}
```