### PR TITLE
fix(keycloak-11): scope "iss" is not valid

### DIFF
--- a/gateway-manager/templates/oidc_template.json
+++ b/gateway-manager/templates/oidc_template.json
@@ -6,7 +6,7 @@
   "config.cookie_domain": "${domain}",
 
   "config.email_key": "email",
-  "config.scope": "openid+profile+email+iss",
+  "config.scope": "openid+profile+email+roles",
   "config.user_info_cache_enabled": "true",
 
   "config.app_login_redirect_url": "${host}/${realm}/${service}/",


### PR DESCRIPTION
`iss` is not in the list of scopes and keycloak 11 complains while keycloak 9 ignores the value.

![image](https://user-images.githubusercontent.com/8459537/91310225-e0810180-e7b1-11ea-8891-616b2ef230c5.png)
