### PR TITLE
fix(kong): redirect after logout with kong-oidc-auth plugin

### DIFF
--- a/kong/Dockerfile
+++ b/kong/Dockerfile
@@ -1,17 +1,15 @@
 ARG VERSION=latest
 FROM kong:$VERSION
 
-# Kong install dir
-ENV KONG_OIDC_HOME /usr/local/share/lua/5.1/kong/plugins/kong-oidc-auth
-ENV KONG_OIDC_REPO https://github.com/eHealthAfrica/kong-oidc-auth.git
-
 # In version 2.0 the active user is kong
 # we need to switch back to root to install the plugin
 USER root
 
-# Install OIDC plugin
-RUN apk -U add --no-cache --virtual .build-deps git unzip gcc libc-dev openssl-dev && \
-    git clone $KONG_OIDC_REPO $KONG_OIDC_HOME && \
+# Install custom OIDC plugin
+ENV KONG_OIDC_HOME /usr/local/share/lua/5.1/kong/plugins/kong-oidc-auth
+COPY ./kong-oidc-auth $KONG_OIDC_HOME/
+
+RUN apk -U add --no-cache --virtual .build-deps unzip gcc libc-dev openssl-dev && \
     cd $KONG_OIDC_HOME && \
     luarocks make *.rockspec && \
     apk del .build-deps

--- a/kong/kong-oidc-auth/README.md
+++ b/kong/kong-oidc-auth/README.md
@@ -1,0 +1,59 @@
+# Kong OIDC Auth
+OpenID Connect authentication integration with the Kong Gateway
+
+## Configuration
+You can add the plugin with the following request:
+
+```bash
+$ curl -X POST http://kong:8001/apis/{api}/plugins \
+    --data "name=kong-oidc-auth" \
+    --data "config.app_login_redirect_url=https://yourapplication.com/loggedin/dashboard" \
+    --data "config.authorize_url=https://oauth.something.net/openid-connect/authorize" \
+    --data "config.client_id=SOME_CLIENT_ID" \
+    --data "config.client_secret=SOME_SECRET_KEY" \
+    --data "config.cookie_domain=.ehealthafrica.org" \
+    --data "config.email_key=email" \
+    --data "config.hosted_domain=ehealthafrica.org" \
+    --data "config.pf_idp_adapter_id=CompanyIdOIDCStage" \
+    --data "config.salt=b3253141ce67204b" \
+    --data "config.scope=openid+profile+email" \
+    --data "config.service_logout_url=https://iam.service/realm/logout" \
+    --data "config.token_url=https://oauth.something.net/openid-connect/token" \
+    --data "config.user_info_cache_enabled=false" \
+    --data "config.user_keys=email,name,sub" \
+    --data "config.user_url=https://oauth.something.net/openid-connect/userinfo"
+```
+
+| Form Parameter | default | description |
+| --- | --- | --- |
+| `name` | | plugin name `kong-oidc-auth` |
+| `config.allowed_roles` <br /> <small>Optional</small> | | An array of roles, any of which should grant access to this route. This will be checked against the `groups` field from your OIDC providers userinfo endpoint. You _must_ make roles available as `userinfo.groups` for this to work, otherwise enabling this option will block all users as their roles will not be retrievable. |
+| `config.app_login_redirect_url` | | Needed for Single Page Applications to redirect after initial authentication successful, otherwise a proxy request following initial authentication would redirect data directly to a users browser! |
+| `config.authorize_url` | | Authorization url of the OAUTH provider (the one to which you will be redirected when not authenticated) |
+| `config.client_id` | | OAUTH Client Id |
+| `config.client_secret` | | OAUTH Client Secret |
+| `config.cookie_domain` | `ehealthafrica.org` | Specify the domain in which this cookie is valid for, realistically will need to match the gateway |
+| `config.email_key` | | Key to be checked for hosted domain, taken from userinfo endpoint |
+| `config.hosted_domain` | | Domain whose users must belong to in order to get logged in. Ignored if empty |
+| `config.pf_idp_adapter_id` <br /> <small>Optional</small> | | OAUTH PingFederate Adaptor ID of the authorization request ex: CompanyIdOIDCStage, essentially points to the idp environment, ping federate specific only |
+| `config.realm` <br /> <small>Optional</small> | | This value will be passed as `X-Oauth-realm` _if and only if_ it is included as part of the request URL. |
+| `config.salt` | `b3253141ce67204b` | Salt for the user session token, must be 16 char alphanumeric |
+| `config.scope` | | OAUTH scope of the authorization request |
+| `config.service_logout_url` | | The URL for logouts in your IAM provider. Will be redirected to this URL when hitting urls ending in `/logout` |
+| `config.token_url` | | The URL of the Oauth provider to request the access token |
+| `config.user_info_cache_enabled` | | This enables storing the userInfo in Kong local cache which enables sending the entire requested user information to the backend service upon every request, otherwise user info only comes back occasionally and backend api service providers are required to validate the EOAuth Cookie Session with cached user information within their logic |
+| `config.user_info_periodic_check` | `60` | Time in seconds between token checks |
+| `config.user_keys` <br /> <small>Optional</small> | `username,email` | keys to extract from the `user_url` endpoint returned json, they will also be added to the headers of the upstream server as `X-OAUTH-XXX` |
+| `config.user_url` | | The URL of the oauth provider used to retrieve user information and also check the validity of the access token |
+
+Data available from the userinfo endpoint and included in the `config.user_keys` section will be included as headers following the pattern `X-Oauth-{field}` to upstream services.
+
+**NOTES**:
+Ping Federate requires you to authorize a callback URL, all proxies have a standard call back route of:
+https://api-gateway.company.com/your/proxy/path/oauth2/callback
+
+## Supported Kong Releases
+Kong >= 1.0
+
+## Source
+https://github.com/Optum/kong-oidc-auth

--- a/kong/kong-oidc-auth/README.md
+++ b/kong/kong-oidc-auth/README.md
@@ -20,7 +20,7 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
     --data "config.service_logout_url=https://iam.service/realm/logout" \
     --data "config.token_url=https://oauth.something.net/openid-connect/token" \
     --data "config.user_info_cache_enabled=false" \
-    --data "config.user_keys=email,name,sub" \
+    --data "config.user_keys=email,username" \
     --data "config.user_url=https://oauth.something.net/openid-connect/userinfo"
 ```
 
@@ -35,7 +35,7 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
 | `config.cookie_domain` | `ehealthafrica.org` | Specify the domain in which this cookie is valid for, realistically will need to match the gateway |
 | `config.email_key` | | Key to be checked for hosted domain, taken from userinfo endpoint |
 | `config.hosted_domain` | | Domain whose users must belong to in order to get logged in. Ignored if empty |
-| `config.pf_idp_adapter_id` <br /> <small>Optional</small> | | OAUTH PingFederate Adaptor ID of the authorization request ex: CompanyIdOIDCStage, essentially points to the idp environment, ping federate specific only |
+| `config.pf_idp_adapter_id` <br /> <small>Optional</small> | | OAUTH PingFederate Adaptor ID of the authorization request ex: `CompanyIdOIDCStage`, essentially points to the idp environment, ping federate specific only |
 | `config.realm` <br /> <small>Optional</small> | | This value will be passed as `X-Oauth-realm` _if and only if_ it is included as part of the request URL. |
 | `config.salt` | `b3253141ce67204b` | Salt for the user session token, must be 16 char alphanumeric |
 | `config.scope` | | OAUTH scope of the authorization request |

--- a/kong/kong-oidc-auth/kong-oidc-auth-0.1-4.rockspec
+++ b/kong/kong-oidc-auth/kong-oidc-auth-0.1-4.rockspec
@@ -1,0 +1,20 @@
+package = "kong-oidc-auth"
+version = "0.1-4"
+source = {
+   url = "git+https://github.com/eHealthAfrica/gateway-manager.git"
+}
+description = {
+   summary  = "OpenID Connect authentication with Kong gateway",
+   detailed = [[Please refer to the documentation associated here: https://github.com/eHealthAfrica/gateway-manager]],
+   homepage = "https://github.com/eHealthAfrica/gateway-manager",
+   license  = "Apache 2.0"
+}
+dependencies = {}
+build = {
+   type = "builtin",
+   modules = {
+      ["kong.plugins.kong-oidc-auth.access"]  = "src/access.lua",
+      ["kong.plugins.kong-oidc-auth.handler"] = "src/handler.lua",
+      ["kong.plugins.kong-oidc-auth.schema"]  = "src/schema.lua"
+   }
+}

--- a/kong/kong-oidc-auth/src/access.lua
+++ b/kong/kong-oidc-auth/src/access.lua
@@ -1,0 +1,432 @@
+local cipher         = require "openssl.cipher"
+local cjson          = require "cjson.safe"
+local http           = require "resty.http"
+local openssl_digest = require "openssl.digest"
+local pl_stringx     = require "pl.stringx"
+local singletons     = require "kong.singletons"
+local str            = require "resty.string"
+
+local _M              = {}
+local aes             = cipher.new("AES-128-CBC")
+local cookie_domain   = nil
+local oidc_error      = nil
+local salt            = nil -- 16 char alphanumeric
+local oauth2_callback = "/oauth2/callback"
+
+--
+-- HELPERS
+--
+
+-- Convenience function for logging objects... because LUA...
+local function dump(o)
+  if type(o) == 'table' then
+    local s = '{ '
+    for k,v in pairs(o) do
+      if type(k) ~= 'number' then
+        k = '"'..k..'"'
+      end
+      s = s .. '['..k..'] = ' .. dump(v) .. ','
+    end
+    return s .. '} '
+  else
+    return tostring(o)
+  end
+end
+
+-- Checks if an object exists in a set
+local function is_member(_obj, _set)
+  for _,v in pairs(_set) do
+    if v == _obj then
+      return true
+    end
+  end
+  return false
+end
+
+local function extract_cookies()
+  if type(ngx.header["Set-Cookie"]) == "table" then
+    return unpack(ngx.header["Set-Cookie"])
+  else
+    return ngx.header["Set-Cookie"]
+  end
+end
+
+function encode_token(token, conf)
+  return ngx.encode_base64(aes:encrypt(openssl_digest.new("md5"):final(conf.client_secret), salt, true):final(token))
+end
+
+function decode_token(token, conf)
+  local status, token = pcall(function () return aes:decrypt(openssl_digest.new("md5"):final(conf.client_secret), salt, true):final(ngx.decode_base64(token)) end)
+  if status then
+    return token
+  else
+    return nil
+  end
+end
+
+function cookie_expires(value)
+  if value == 0 then
+    return "Path=/;Expires=Thu, Jan 01 1970 00:00:00 UTC;Max-Age=0;HttpOnly;"
+  end
+  return ";Path=/;Expires=" .. ngx.cookie_time(ngx.time() + value) .. ";Max-Age=" .. value .. ";HttpOnly;"
+end
+
+--
+-- BASIC AUTH
+--
+
+-- Get A token via PasswordGrant
+local function getTokenViaBasic(user, pw, conf)
+  local httpc = http:new()
+  local res, err = httpc:request_uri(conf.token_url, {
+    method = "POST",
+    ssl_verify = false,
+    body = "grant_type=password&client_id=" .. conf.client_id .. "&client_secret=" .. conf.client_secret .. "&username=" .. user .. "&password=" .. pw .. "&scope=" .. conf.scope,
+    headers = {
+      ["Content-Type"] = "application/x-www-form-urlencoded",
+    }
+  })
+  return res, err
+end
+
+-- Extract credential parts from {user}:{pw}
+local function credsFromBasic(authString)
+  local m, err = ngx.re.match(authString, "(?<user>[^:]+):(?<pw>[^:]+)", "ao")
+  return m
+end
+
+-- Cache failure callback function that handles basicauth
+local function tokenFromBasic(base64_basic, conf)
+  local plain_text = ngx.decode_base64(base64_basic)
+  local c          = credsFromBasic(plain_text)
+
+  if c["user"] == nil or c["pw"] == nil then
+    return nil
+  end
+
+  local res, err = getTokenViaBasic(c["user"], c["pw"], conf)
+  if err ~= nil then
+    return nil
+  end
+  if res.status ~= 200 then
+    return nil
+  end
+
+  local userJson = cjson.decode(res.body)
+  return encode_token(userJson['access_token'], conf)
+end
+
+-- get Userinfo from AuthProvider's userinfo endpoint
+local function getUserInfo(access_token, callback_url, conf)
+  local httpc = http:new()
+  local res, err = httpc:request_uri(conf.user_url, {
+      method = "GET",
+      ssl_verify = false,
+      headers = {
+        ["Authorization"] = "Bearer " .. access_token,
+      }
+  })
+
+  -- redirect to auth if user result is invalid not 200
+  if res.status ~= 200 then
+    return redirect_to_auth(conf, callback_url)
+  end
+
+  local userJson = cjson.decode(res.body)
+  return userJson
+end
+
+
+local function getKongKey(eoauth_token, access_token, callback_url, conf)
+  -- This will add a 28800 second (8 hour) expiring TTL on this cached value
+  -- https://github.com/thibaultcha/lua-resty-mlcache/blob/master/README.md
+  local userInfo, err = singletons.cache:get(eoauth_token, { ttl = conf.user_info_periodic_check }, getUserInfo, access_token, callback_url, conf)
+
+  if err then
+    ngx.log(ngx.ERR, "Could not retrieve UserInfo: ", err)
+    return
+  end
+  return userInfo
+end
+
+
+local function validate_roles(conf, token)
+  local _allowed_roles = conf.allowed_roles
+  local _next = next(_allowed_roles)
+  if _next == nil then
+    return true -- no roles provided for checking. Ok.
+  end
+  if token["groups"] == nil then
+    ngx.log(ngx.ERR, 'oidc.userinfo.groups not availble! Check keycloak settings.')
+    return false
+  end
+  for _, role in pairs(_allowed_roles) do
+    if (is_member(role, token["groups"]) == true) then
+      return true
+    end
+  end
+  return false -- no matching roles
+end
+
+
+function redirect_to_auth(conf, callback_url)
+  -- Track the endpoint they wanted access to so we can transparently redirect them back
+  -- For Calls to indicate they prefer a 403 instead of redirect to the Oauth provider,
+  -- a header of X-Oauth-Unauthorized can be set to `status_code | login`
+  local login_pref = ngx.req.get_headers()["X-Oauth-Unauthorized"]
+  if login_pref ~= nil and login_pref == "status_code" then
+    return kong.response.exit(403, { message = "Forbidden: Auth redirect aborted on X-Oauth-Unauthorized == status_code" })
+  end
+
+  local redirect_url = ngx.var.request_uri
+  if (string.find(redirect_url, oauth2_callback)) then
+    redirect_url = conf.app_login_redirect_url
+  end
+  ngx.header["Set-Cookie"] = { "EOAuthRedirectBack=" .. redirect_url .. cookie_expires(120), extract_cookies() }
+
+  -- Redirect to the /oauth endpoint
+  local oauth_authorize = nil
+  if(conf.pf_idp_adapter_id == "") then -- Standard Auth URL (Something other than ping)
+    oauth_authorize = conf.authorize_url .. "?response_type=code&client_id=" .. conf.client_id .. "&redirect_uri=" .. callback_url .. "&scope=" .. conf.scope
+  else -- Ping Federate Auth URL
+    oauth_authorize = conf.authorize_url .. "?pfidpadapterid=" .. conf.pf_idp_adapter_id .. "&response_type=code&client_id=" .. conf.client_id .. "&redirect_uri=" .. callback_url .. "&scope=" .. conf.scope
+  end
+
+  return ngx.redirect(oauth_authorize)
+end
+
+
+-- Logout Handling
+function handle_logout(encrypted_token, conf)
+  -- Terminate the Cookie
+  local redirect_url = string.format("%s?redirect_uri=%s", conf.service_logout_url, conf.app_login_redirect_url)
+
+  ngx.header["Set-Cookie"] = { "EOAuthToken=;" .. cookie_expires(0) .. cookie_domain, extract_cookies() }
+  if conf.realm ~= nil then
+    ngx.header["Set-Cookie"] = { "EOAuthRealm=;" .. cookie_expires(0) .. cookie_domain, extract_cookies() }
+  end
+
+  -- Remove session
+  if conf.user_info_cache_enabled then
+    singletons.cache:invalidate(encrypted_token)
+  end
+  -- Redirect to IAM service logout
+  return ngx.redirect(redirect_url)
+end
+
+-- Callback Handling
+function handle_callback(conf, callback_url)
+  local args = ngx.req.get_uri_args()
+  local code = args.code
+  local redirect_url
+
+  if args.redirect_url == nil then
+    redirect_url = callback_url
+  else
+    redirect_url = args.redirect_url
+  end
+
+  if code then
+    local httpc = http:new()
+    local res, err = httpc:request_uri(conf.token_url, {
+      method = "POST",
+      ssl_verify = false,
+      body = "grant_type=authorization_code&client_id=" .. conf.client_id .. "&client_secret=" .. conf.client_secret .. "&code=" .. code .. "&redirect_uri=" .. redirect_url,
+      headers = {
+        ["Content-Type"] = "application/x-www-form-urlencoded",
+      }
+    })
+
+    if not res then
+      oidc_error = {status = ngx.HTTP_INTERNAL_SERVER_ERROR, message = "Failed to request: " .. err}
+      return kong.response.exit(oidc_error.status, { message = oidc_error.message })
+    end
+
+    local body_json    = cjson.decode(res.body)
+    local access_token = body_json.access_token
+    if not access_token then
+      oidc_error = {status = ngx.HTTP_BAD_REQUEST, message = body_json.error_description}
+      return kong.response.exit(oidc_error.status, { message = oidc_error.message })
+    end
+
+    ngx.header["Set-Cookie"] = { "EOAuthToken=" .. encode_token(access_token, conf) .. cookie_expires(1800) .. cookie_domain, extract_cookies() }
+    if conf.realm ~= nil then
+      ngx.header["Set-Cookie"] = { "EOAuthRealm=" .. conf.realm .. cookie_expires(1800) .. cookie_domain, extract_cookies() }
+    end
+
+    -- Support redirection back to Kong if necessary
+    local redirect_back = ngx.var.cookie_EOAuthRedirectBack
+
+    if redirect_back then
+      return ngx.redirect(redirect_back) -- Should always land here if no custom Logged in page defined!
+    else
+      --return redirect_to_auth(conf, callback_url)
+      return
+    end
+  else
+    oidc_error = {status = ngx.HTTP_UNAUTHORIZED, message = "User has denied access to the resources"}
+    return kong.response.exit(oidc_error.status, { message = oidc_error.message })
+  end
+end
+
+--
+-- MAIN Function that Kong runs
+--
+
+function _M.run(conf)
+  local path_prefix = ""
+  local callback_url = ""
+
+  cookie_domain = "Domain=" .. conf.cookie_domain .. ";"
+  salt = conf.salt
+
+  -- Fix for /api/team/POC/oidc/v1/service/oauth2/callback?code=*******
+  if ngx.var.request_uri:find('?') then
+    path_prefix = ngx.var.request_uri:sub(1, ngx.var.request_uri:find('?') -1)
+  else
+    path_prefix = ngx.var.request_uri
+  end
+
+  local scheme = ""
+  if conf.use_ssl then
+    scheme = "https"
+  else
+    scheme = ngx.var.scheme
+  end
+
+  if pl_stringx.endswith(path_prefix, "/") then
+    path_prefix = path_prefix:sub(1, path_prefix:len() - 1)
+    callback_url = scheme .. "://" .. ngx.var.host .. path_prefix .. oauth2_callback
+  elseif pl_stringx.endswith(path_prefix, oauth2_callback) then -- We are in the callback of our proxy
+    callback_url = scheme .. "://" .. ngx.var.host .. path_prefix
+    handle_callback(conf, callback_url)
+  else
+    callback_url = scheme .. "://" .. ngx.var.host .. path_prefix .. oauth2_callback
+  end
+
+  -- See if we have a token
+
+  -- Try to get token from Bearer string
+
+  local auth_header = ngx.var.http_Authorization
+  local access_token = nil
+  local encrypted_token
+
+  if auth_header then
+    local _ -- Keep off the global scope
+    _, _, access_token = string.find(auth_header, "Bearer%s+(.+)")
+  end
+  -- Try to Perform BasicAuth
+  if auth_header and access_token == nil then
+    local _ -- Keep off the global scope
+    local base64_basic
+    _, _, base64_basic = string.find(auth_header, "Basic%s+(.+)")
+    if base64_basic ~= nil then
+      local err
+      local hashed = encode_token(base64_basic, conf)
+      encrypted_token, err = singletons.cache:get("basicauth." .. hashed, { ttl = conf.user_info_periodic_check }, tokenFromBasic, base64_basic, conf)
+      if not encrypted_token then
+        return kong.response.exit(401, { message = "Invalid Credentials" })
+      end
+    end
+  else
+    -- Try to get token from cookie
+    encrypted_token = ngx.var.cookie_EOAuthToken
+  end
+
+  -- No token, send to auth
+  if encrypted_token == nil and access_token == nil then
+    return redirect_to_auth(conf, callback_url)
+  end
+
+  if encrypted_token == nil then
+    -- make an encoded token from the passed access_token
+    encrypted_token = encode_token(access_token, conf)
+  end
+  -- check if we are authenticated already
+  if access_token == nil then
+    access_token = decode_token(encrypted_token, conf)
+    if not access_token then
+      -- broken access token
+      return redirect_to_auth(conf, callback_url)
+    end
+  end
+
+  -- They had a valid EOAuthToken so its safe to process a proper logout now.
+  if pl_stringx.endswith(path_prefix, "/logout") then
+    return handle_logout(encrypted_token, conf)
+  end
+
+  -- Make sure referer header is set for all HTTPS traffic
+  if scheme == "https" and ngx.header["referer"] == nil then
+    ngx.header["referer"] = scheme .. "://" .. ngx.var.host
+  end
+
+  -- Update the Cookie to increase longevity for 30 more minutes if active proxying
+  ngx.header["Set-Cookie"] = { "EOAuthToken=" .. encode_token(access_token, conf) .. cookie_expires(1800) .. cookie_domain, extract_cookies() }
+  if conf.realm ~= nil then
+    ngx.header["Set-Cookie"] = { "EOAuthRealm=" .. conf.realm .. cookie_expires(1800) .. cookie_domain, extract_cookies() }
+  end
+
+   -- CACHE LOGIC - Check boolean and then if EOAUTH has existing key -> userInfo value
+  if conf.user_info_cache_enabled then
+    local userInfo = getKongKey(encrypted_token, access_token, callback_url, conf)
+    if userInfo then
+      -- Check if allowed_roles is set && enforce
+      local valid = validate_roles(conf, userInfo)
+      if valid == false then
+        return kong.response.exit(401, { message = "User lacks valid role for this OIDC resource" })
+      end
+
+      for i, key in ipairs(conf.user_keys) do
+        ngx.header["X-Oauth-".. key] = userInfo[key]
+        ngx.req.set_header("X-Oauth-".. key, userInfo[key])
+      end
+
+      if (conf.realm ~= "" and (pl_stringx.count(ngx.var.request_uri, conf.realm) > 0)) then -- inject realm name into headers
+        ngx.header["X-Oauth-realm"] = conf.realm
+        ngx.req.set_header("X-Oauth-realm", conf.realm)
+      end
+
+      ngx.req.set_header("X-Oauth-Token", access_token)
+      ngx.header["X-Oauth-Token"] = access_token
+      return
+    end
+  end
+  -- END OF NEW CACHE LOGIC --
+
+  -- Get user info
+  if not ngx.var.cookie_EOAuthUserInfo then
+    local json = getUserInfo(access_token, callback_url, conf)
+    if json then
+      -- Check if allowed_roles is set && enforce
+      local valid = validate_roles(conf, json)
+      if valid == false then
+        return kong.response.exit(401, { message = "User lacks valid role for this OIDC resource" })
+      end
+      if conf.hosted_domain ~= "" and conf.email_key ~= "" then
+        if not pl_stringx.endswith(json[conf.email_key], conf.hosted_domain) then
+          oidc_error = {status = ngx.HTTP_UNAUTHORIZED, message = "Hosted domain is not matching"}
+          return kong.response.exit(oidc_error.status, { message = oidc_error.message })
+        end
+      end
+
+      for i, key in ipairs(conf.user_keys) do
+        ngx.header["X-Oauth-".. key] = json[key]
+        ngx.req.set_header("X-Oauth-".. key, json[key])
+      end
+      if (conf.realm ~= "" and (pl_stringx.count(ngx.var.request_uri, conf.realm) > 0)) then -- inject realm name into headers
+        ngx.header["X-Oauth-realm"] = conf.realm
+        ngx.req.set_header("X-Oauth-realm", conf.realm)
+      end
+      ngx.req.set_header("X-Oauth-Token", access_token)
+      ngx.header["X-Oauth-Token"] = access_token
+
+      ngx.header["Set-Cookie"] = { "EOAuthUserInfo=0;" .. cookie_expires(conf.user_info_periodic_check), extract_cookies() }
+    else
+      return kong.response.exit(500, { message = "Could not get UserInfo" })
+    end
+  end
+end
+
+return _M

--- a/kong/kong-oidc-auth/src/handler.lua
+++ b/kong/kong-oidc-auth/src/handler.lua
@@ -1,0 +1,15 @@
+local BasePlugin = require "kong.plugins.base_plugin"
+local access     = require "kong.plugins.kong-oidc-auth.access"
+
+local KongOidcAuth = BasePlugin:extend()
+
+function KongOidcAuth:new()
+  KongOidcAuth.super.new(self, "kong-oidc-auth")
+end
+
+function KongOidcAuth:access(conf)
+  KongOidcAuth.super.access(self)
+  access.run(conf)
+end
+
+return KongOidcAuth

--- a/kong/kong-oidc-auth/src/schema.lua
+++ b/kong/kong-oidc-auth/src/schema.lua
@@ -1,0 +1,37 @@
+local url = require "socket.url"
+
+local function validate_url(value)
+  local parsed_url = url.parse(value)
+  if parsed_url.scheme and parsed_url.host then
+    parsed_url.scheme = parsed_url.scheme:lower()
+    if not (parsed_url.scheme == "http" or parsed_url.scheme == "https") then
+      return false, "Supported protocols are HTTP and HTTPS"
+    end
+  end
+
+  return true
+end
+
+return {
+  fields = {
+    allowed_roles            = {type = "array", default = {}},
+    app_login_redirect_url   = {type = "string", default = "", required = false},
+    authorize_url            = {type = "url", func = validate_url, required = true},
+    client_id                = {type = "string", required = true},
+    client_secret            = {type = "string", required = true},
+    cookie_domain            = {type = "string", default = "ehealthafrica.org"},
+    email_key                = {type = "string", default = ""},
+    hosted_domain            = {type = "string", default = ""},
+    pf_idp_adapter_id        = {type = "string", default = ""},
+    realm                    = {type = "string", default = ""},
+    salt                     = {type = "string", default = "b3253141ce67204b", required = true},
+    scope                    = {type = "string", default = ""},
+    service_logout_url       = {type = "string", default = "", required = false},
+    token_url                = {type = "url", func = validate_url, required = true},
+    use_ssl                  = {type = "boolean", default = false},
+    user_info_cache_enabled  = {type = "boolean", default = false},
+    user_info_periodic_check = {type = "number", default = 60, required = true},
+    user_keys                = {type = "array", default = {"username", "email"}},
+    user_url                 = {type = "url", func = validate_url, required = true}
+  }
+}

--- a/kong/nginx_templates/nginx_kong.lua.patch
+++ b/kong/nginx_templates/nginx_kong.lua.patch
@@ -7,10 +7,10 @@
         if err then
             ngx.log(ngx.WARN, err)
         elseif (ngx.var["cookie_EOAuthRealm"] ~= nil and m ~= nil) then
-            local service  = m["app"]
+            local service       = m["app"]
             local remaining_url = m["url"]
-            local realm = ngx.var["cookie_EOAuthRealm"]
-            local args = ngx.req.get_uri_args()
+            local realm         = ngx.var["cookie_EOAuthRealm"]
+            local args          = ngx.req.get_uri_args()
             if args ~= nil then
                 local friendly_args = ngx.encode_args(args)
                 ngx.log(ngx.INFO, realm .. "/" .. service .. "/" .. service .. "-app" .. remaining_url .. "?" .. friendly_args)


### PR DESCRIPTION
Added whole plugin code source to this repository (mentioning sources).
Fixed issue with timeout after logout.

## How to reproduce the error:
  - logout
  - wait for more than 5 minutes
  - log in again
  - you will be redirected to the login again because the keycloak login token expired (at this points is when error happens because the redirect url is now the URL that checked the expired login session).
  - log in again
  - you'll see an error response from keycloak

    ![image](https://user-images.githubusercontent.com/8459537/104202798-ab591100-542b-11eb-8bb4-db8bbe52202f.png)

## What does the patch?
It checks that the redirect URL is not related to the OAUTH2 platform, otherwise it uses to the global configuration option `app_login_redirect_url`.