### PR TITLE
drop /auth from the authentication url for keycloak v24

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Review the code to get the expected strings in each case.
 
 ### Keycloak
 
-- `KEYCLOAK_INTERNAL`: Keycloak internal URL. Usually `http://keycloak:8080/auth/`.
+- `KEYCLOAK_INTERNAL`: Keycloak internal URL. Usually `http://keycloak:8080/`.
   **Note**: Ending `/` is required to connect to admin console.
 - `KEYCLOAK_MASTER_REALM`: Keycloak master realm name. Defaults to `master`.
 - `KEYCLOAK_GLOBAL_ADMIN`: Keycloak admin user in the master realm.

--- a/gateway-manager/conf/pip/requirements.txt
+++ b/gateway-manager/conf/pip/requirements.txt
@@ -35,7 +35,7 @@ pyjwt
 # Python package providing access to the Keycloak API.
 # https://python-keycloak.readthedocs.io/en/latest/
 # https://github.com/marcospereirampj/python-keycloak
-python-keycloak>=0.17
+python-keycloak>=4.0.1
 
 # Implements a higher level API to Apache Zookeeper for Python clients.
 # https://kazoo.readthedocs.io/en/latest/

--- a/gateway-manager/src/manage_home_app.py
+++ b/gateway-manager/src/manage_home_app.py
@@ -85,7 +85,7 @@ def start_app():
         return render_template(
             'landing-page.html',
             # realm urls
-            account_url=f'{BASE_HOST}/auth/realms/{realm}/account',
+            account_url=f'{BASE_HOST}/realms/{realm}/account',
             base_url=f'{BASE_HOST}/{realm}',
             logout_url=f'{BASE_HOST}/{realm}/{WEB_SERVICE_NAME}/logout',
             static_url=f'{BASE_HOST}{STATIC_URL}',

--- a/gateway-manager/src/manage_keycloak.py
+++ b/gateway-manager/src/manage_keycloak.py
@@ -67,13 +67,13 @@ def get_client(exit_on_error=True):
         LOGGER.error(str(ke))
         if exit_on_error:
             sys.exit(1)
-        raise e
+        raise ke
 
 
 def client_for_realm(realm, exit_on_error=True):
     try:
         keycloak_admin = get_client(exit_on_error)
-        keycloak_admin.realm_name = realm
+        keycloak_admin.change_current_realm(realm)
         # keycloak_admin.users_count()  # check that realm exists
         return keycloak_admin
 

--- a/gateway-manager/src/settings.py
+++ b/gateway-manager/src/settings.py
@@ -73,7 +73,7 @@ TEMPLATES = {
 
 # Keycloak Information
 
-KC_ADMIN_URL = get_env('KEYCLOAK_INTERNAL')     # http://keycloak:8080/auth/
+KC_ADMIN_URL = get_env('KEYCLOAK_INTERNAL')     # http://keycloak:8080/
 KC_ADMIN_USER = get_env('KEYCLOAK_GLOBAL_ADMIN')
 KC_ADMIN_PASSWORD = get_env('KEYCLOAK_GLOBAL_PASSWORD')
 KC_ADMIN_REALM = get_env('KEYCLOAK_MASTER_REALM', 'master')

--- a/gateway-manager/templates/oidc_template.json
+++ b/gateway-manager/templates/oidc_template.json
@@ -11,10 +11,10 @@
   "config.user_info_cache_enabled": "true",
 
   "config.app_login_redirect_url": "${host}/${realm}/${service}/",
-  "config.authorize_url": "${host}/auth/realms/${realm}/protocol/openid-connect/auth",
-  "config.service_logout_url": "${host}/auth/realms/${realm}/protocol/openid-connect/logout",
-  "config.token_url": "${host}/auth/realms/${realm}/protocol/openid-connect/token",
-  "config.user_url": "${host}/auth/realms/${realm}/protocol/openid-connect/userinfo",
+  "config.authorize_url": "${host}/realms/${realm}/protocol/openid-connect/auth",
+  "config.service_logout_url": "${host}/realms/${realm}/protocol/openid-connect/logout",
+  "config.token_url": "${host}/realms/${realm}/protocol/openid-connect/token",
+  "config.user_url": "${host}/realms/${realm}/protocol/openid-connect/userinfo",
 
   "config.use_ssl": "${use_ssl}",
   "config.realm": "${realm}"


### PR DESCRIPTION
# Description
Update all references to the **Keycloak** authentication `url` within scripts and config files; drop`/auth/` in the url as this is no longer present in recent Quarkus distributions of **Keycloak** like version `24.x` currently in use.

See this Stackoverflow [page](https://stackoverflow.com/questions/65711806/keycloak-redirect-page-shows-we-are-sorry-page-not-found) and Keycloak [docs](https://www.keycloak.org/migration/migrating-to-quarkus).