### PR TITLE
Clear keycloak_admin realm cache to avoid auth issues

### DIFF
--- a/gateway-manager/Dockerfile
+++ b/gateway-manager/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update -qq && \
         --allow-downgrades \
         --allow-remove-essential \
         --allow-change-held-packages \
-        install gcc git curl && \
-    curl -L https://cnfl.io/ccloud-cli | sh -s -- -b /usr/local/bin
+        install gcc git curl
+#    curl -L https://cnfl.io/ccloud-cli | sh -s -- -b /usr/local/bin
 
 COPY ./conf/pip /code/conf/pip
 

--- a/gateway-manager/src/manage_keycloak.py
+++ b/gateway-manager/src/manage_keycloak.py
@@ -73,6 +73,9 @@ def get_client(exit_on_error=True):
 def client_for_realm(realm, exit_on_error=True):
     try:
         keycloak_admin = get_client(exit_on_error)
+        # sometimes authentication fails, this is due to some internal caching
+        # clear the internal caching first
+        keycloak_admin.clear_realm_cache()
         keycloak_admin.change_current_realm(realm)
         # keycloak_admin.users_count()  # check that realm exists
         return keycloak_admin


### PR DESCRIPTION
Due to some internal caching authenticating with keycloak fails sometimes with the keycloak_admin python library. Clearing the cache when getting the client fixes this