### PR TITLE
add back the /auth/ prefix

### DIFF
--- a/gateway-manager/templates/oidc_template.json
+++ b/gateway-manager/templates/oidc_template.json
@@ -11,10 +11,10 @@
   "config.user_info_cache_enabled": "true",
 
   "config.app_login_redirect_url": "${host}/${realm}/${service}/",
-  "config.authorize_url": "${host}/realms/${realm}/protocol/openid-connect/auth",
-  "config.service_logout_url": "${host}/realms/${realm}/protocol/openid-connect/logout",
-  "config.token_url": "${host}/realms/${realm}/protocol/openid-connect/token",
-  "config.user_url": "${host}/realms/${realm}/protocol/openid-connect/userinfo",
+  "config.authorize_url": "${host}/auth/realms/${realm}/protocol/openid-connect/auth",
+  "config.service_logout_url": "${host}/auth/realms/${realm}/protocol/openid-connect/logout",
+  "config.token_url": "${host}/auth/realms/${realm}/protocol/openid-connect/token",
+  "config.user_url": "${host}/auth/realms/${realm}/protocol/openid-connect/userinfo",
 
   "config.use_ssl": "${use_ssl}",
   "config.realm": "${realm}"


### PR DESCRIPTION
we removed the /auth in the keycloak configuration, but this needs to be added back because it is proxied by kong and expected by keycloak because we are using `KC_HTTP_RELATIVE_PATH=/auth`